### PR TITLE
Add Mirage provider docs and example configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,212 @@
+# Terraform Provider Mirage
+
+A Terraform provider for managing Airflow DAG generation through the Mirage ecosystem.
+
+## Overview
+
+The Mirage provider allows you to generate Airflow DAGs from Jinja2 templates and manage them in Google Cloud Storage. It integrates with a backend service to handle template rendering and file management.
+
+## Requirements
+
+- Terraform >= 1.0
+- Go >= 1.24 (for development)
+- Google Cloud Platform credentials (if using GCP authentication)
+
+## Installation
+
+### Using Terraform Registry
+
+Add the following to your Terraform configuration:
+
+```hcl
+terraform {
+  required_providers {
+    mirage = {
+      source  = "localhost/my-org/mirage"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "mirage" {
+  # Configuration options
+}
+```
+
+### Local Development
+
+For local development, build and install the provider:
+
+```bash
+go build -o terraform-provider-mirage
+mkdir -p ~/.terraform.d/plugins/localhost/my-org/mirage/1.0.0/darwin_amd64
+cp terraform-provider-mirage ~/.terraform.d/plugins/localhost/my-org/mirage/1.0.0/darwin_amd64/
+```
+
+## Provider Configuration
+
+The provider currently requires no configuration at the provider level. All configuration is done at the resource level.
+
+```hcl
+provider "mirage" {
+  # No configuration required
+}
+```
+
+## Resources
+
+### `mirage_dag_generator`
+
+Manages a generated file (typically an Airflow DAG) in Google Cloud Storage by processing Jinja2 templates.
+
+#### Example Usage
+
+##### Using a GCS Template
+
+```hcl
+resource "mirage_dag_generator" "example_dag" {
+  dag_generator_backend_url = "https://your-backend-service.com"
+  template_gcs_path        = "gs://your-bucket/templates/dag_template.py.j2"
+  target_gcs_path          = "gs://your-bucket/dags/generated_dag.py"
+  context_json             = jsonencode({
+    dag_id = "example_dag"
+    schedule_interval = "0 2 * * *"
+    owner = "data-team"
+  })
+  use_gcp_service_account_auth = true
+}
+```
+
+##### Using Inline Template Content
+
+```hcl
+resource "mirage_dag_generator" "inline_dag" {
+  dag_generator_backend_url = "https://your-backend-service.com"
+  template_content         = file("${path.module}/templates/dag_template.py.j2")
+  target_gcs_path          = "gs://your-bucket/dags/inline_dag.py"
+  context_json             = jsonencode({
+    dag_id = "inline_dag"
+    schedule_interval = "@daily"
+  })
+  use_gcp_service_account_auth = false
+}
+```
+
+#### Argument Reference
+
+- `dag_generator_backend_url` - (Required) The base URL of the backend service for DAG generation.
+- `target_gcs_path` - (Required) The full `gs://` path for the generated output file.
+- `template_gcs_path` - (Optional) The full `gs://` path to the source Jinja2 template. Mutually exclusive with `template_content`.
+- `template_content` - (Optional) The content of the template as a string. Mutually exclusive with `template_gcs_path`.
+- `context_json` - (Optional) A JSON string representing the dynamic context for template rendering.
+- `use_gcp_service_account_auth` - (Optional) If true, authenticate requests using the machine's GCP service account. Default: `false`.
+
+#### Attributes Reference
+
+- `id` - The GCS path of the generated file.
+- `generated_file_checksum` - The CRC32C checksum of the generated file in GCS.
+- `gcs_generation_number` - The GCS generation number of the generated file.
+
+#### Import
+
+DAG generator resources can be imported using the target GCS path:
+
+```bash
+terraform import mirage_dag_generator.example gs://your-bucket/dags/generated_dag.py
+```
+
+## Authentication
+
+The provider supports two authentication methods:
+
+### 1. GCP Service Account Authentication
+
+Set `use_gcp_service_account_auth = true` in your resource configuration. The provider will use:
+- ID tokens for service account authentication
+- OAuth2 access tokens as fallback for user credentials
+
+### 2. No Authentication
+
+Set `use_gcp_service_account_auth = false` or omit the attribute. Requests will be sent without authentication headers.
+
+## Backend Service Requirements
+
+The Mirage provider expects a backend service with the following endpoints:
+
+### POST `/generate`
+
+Generate or update a DAG file.
+
+**Request Body:**
+```json
+{
+  "template_gcs_path": "gs://bucket/template.j2",
+  "template_content": "template content string",
+  "target_gcs_path": "gs://bucket/output.py",
+  "context_json": "{\"key\": \"value\"}"
+}
+```
+
+**Response:**
+```json
+{
+  "checksum": "abc123",
+  "generation": "1234567890"
+}
+```
+
+### GET `/status`
+
+Get the current status of a generated file.
+
+**Query Parameters:**
+- `target_gcs_path` - The GCS path of the file
+
+**Response:**
+```json
+{
+  "checksum": "abc123",
+  "generation": "1234567890"
+}
+```
+
+### POST `/delete`
+
+Delete a generated file.
+
+**Request Body:**
+```json
+{
+  "target_gcs_path": "gs://bucket/file.py"
+}
+```
+
+## Development
+
+### Building the Provider
+
+```bash
+go build -o terraform-provider-mirage
+```
+
+### Running Tests
+
+```bash
+go test ./...
+```
+
+### Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Add tests
+5. Submit a pull request
+
+## License
+
+This project is licensed under the terms specified in the LICENSE file.
+
+## Support
+
+For issues and questions, please open an issue in the GitHub repository. 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,36 @@
+# Mirage Provider
+
+The Mirage provider is used to manage Airflow DAG generation through the Mirage ecosystem. It allows you to generate DAGs from Jinja2 templates and store them in Google Cloud Storage.
+
+## Example Usage
+
+```terraform
+terraform {
+  required_providers {
+    mirage = {
+      source  = "localhost/my-org/mirage"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "mirage" {
+  # Configuration options
+}
+
+resource "mirage_dag_generator" "example" {
+  dag_generator_backend_url = "https://your-backend-service.com"
+  template_gcs_path        = "gs://your-bucket/templates/dag_template.py.j2"
+  target_gcs_path          = "gs://your-bucket/dags/generated_dag.py"
+  context_json             = jsonencode({
+    dag_id = "example_dag"
+    schedule_interval = "0 2 * * *"
+    owner = "data-team"
+  })
+  use_gcp_service_account_auth = true
+}
+```
+
+## Schema
+
+The provider schema is currently empty as all configuration is done at the resource level. 

--- a/docs/resources/dag_generator.md
+++ b/docs/resources/dag_generator.md
@@ -1,0 +1,132 @@
+# mirage_dag_generator Resource
+
+Manages a generated file (typically an Airflow DAG) in Google Cloud Storage by processing Jinja2 templates through a backend service.
+
+## Example Usage
+
+### Using a GCS Template
+
+```terraform
+resource "mirage_dag_generator" "example_dag" {
+  dag_generator_backend_url = "https://your-backend-service.com"
+  template_gcs_path        = "gs://your-bucket/templates/dag_template.py.j2"
+  target_gcs_path          = "gs://your-bucket/dags/generated_dag.py"
+  context_json             = jsonencode({
+    dag_id = "example_dag"
+    schedule_interval = "0 2 * * *"
+    owner = "data-team"
+    retries = 3
+  })
+  use_gcp_service_account_auth = true
+}
+```
+
+### Using Inline Template Content
+
+```terraform
+resource "mirage_dag_generator" "inline_dag" {
+  dag_generator_backend_url = "https://your-backend-service.com"
+  template_content         = file("${path.module}/templates/dag_template.py.j2")
+  target_gcs_path          = "gs://your-bucket/dags/inline_dag.py"
+  context_json             = jsonencode({
+    dag_id = "inline_dag"
+    schedule_interval = "@daily"
+    start_date = "2024-01-01"
+  })
+  use_gcp_service_account_auth = false
+}
+```
+
+### Complex Context Example
+
+```terraform
+resource "mirage_dag_generator" "complex_dag" {
+  dag_generator_backend_url = "https://dag-generator.example.com"
+  template_gcs_path        = "gs://my-templates/complex_dag.py.j2"
+  target_gcs_path          = "gs://my-dags/complex_dag.py"
+  context_json             = jsonencode({
+    dag_id = "complex_processing_dag"
+    schedule_interval = "0 */6 * * *"
+    owner = "analytics-team"
+    email = ["team@company.com"]
+    depends_on_past = false
+    catchup = false
+    max_active_runs = 1
+    tasks = [
+      {
+        task_id = "extract_data"
+        command = "python /scripts/extract.py"
+        pool = "default_pool"
+      },
+      {
+        task_id = "transform_data"
+        command = "python /scripts/transform.py"
+        pool = "heavy_pool"
+      },
+      {
+        task_id = "load_data"
+        command = "python /scripts/load.py"
+        pool = "default_pool"
+      }
+    ]
+  })
+  use_gcp_service_account_auth = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `dag_generator_backend_url` - (Required) The base URL of the backend service for DAG generation.
+* `target_gcs_path` - (Required) The full `gs://` path for the generated output file.
+* `template_gcs_path` - (Optional) The full `gs://` path to the source Jinja2 template. Mutually exclusive with `template_content`.
+* `template_content` - (Optional) The content of the template as a string. Mutually exclusive with `template_gcs_path`.
+* `context_json` - (Optional) A JSON string representing the dynamic context for template rendering.
+* `use_gcp_service_account_auth` - (Optional) If true, authenticate requests using the machine's GCP service account. Defaults to `false`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The GCS path of the generated file (same as `target_gcs_path`).
+* `generated_file_checksum` - The CRC32C checksum of the generated file in GCS.
+* `gcs_generation_number` - The GCS generation number of the generated file.
+
+## Import
+
+DAG generator resources can be imported using the target GCS path:
+
+```bash
+terraform import mirage_dag_generator.example gs://your-bucket/dags/generated_dag.py
+```
+
+## Notes
+
+### Template Source Requirements
+
+You must specify exactly one of `template_gcs_path` or `template_content`. The resource will fail if both are specified or if neither is specified.
+
+### Authentication
+
+When `use_gcp_service_account_auth` is set to `true`, the provider will:
+1. First attempt to use ID tokens for service account authentication
+2. Fall back to OAuth2 access tokens if user credentials are detected
+3. Log authentication method selection for debugging
+
+### File Management
+
+The resource tracks the generated file using:
+- **Checksum**: CRC32C checksum for content verification
+- **Generation Number**: GCS generation number for versioning
+
+These values are updated on each successful generation and can be used for drift detection.
+
+### Backend Service Integration
+
+This resource requires a compatible backend service with the following endpoints:
+- `POST /generate` - Generate or update a file
+- `GET /status` - Get file status and metadata
+- `POST /delete` - Delete a file
+
+See the main provider documentation for detailed API specifications. 

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,0 +1,70 @@
+# Basic Mirage Provider Example
+
+This example demonstrates the basic usage of the Mirage provider to generate a simple Airflow DAG from a Jinja2 template stored in Google Cloud Storage.
+
+## Prerequisites
+
+1. A backend service running and accessible at your configured URL
+2. Google Cloud Storage bucket with appropriate permissions
+3. A Jinja2 template file uploaded to GCS
+4. GCP credentials configured (if using service account auth)
+
+## Usage
+
+1. Update the configuration in `main.tf` with your actual values:
+   - `dag_generator_backend_url`: Your backend service URL
+   - `template_gcs_path`: Path to your Jinja2 template in GCS
+   - `target_gcs_path`: Desired output path for the generated DAG
+
+2. Initialize and apply the configuration:
+   ```bash
+   terraform init
+   terraform plan
+   terraform apply
+   ```
+
+3. The provider will:
+   - Send the template and context to your backend service
+   - Generate the DAG file and store it in GCS
+   - Track the file's checksum and generation number
+
+## Example Template
+
+Here's a simple Jinja2 template that could be used with this example:
+
+```python
+from datetime import datetime, timedelta
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+
+default_args = {
+    'owner': '{{ owner }}',
+    'depends_on_past': False,
+    'start_date': datetime.strptime('{{ start_date }}', '%Y-%m-%d'),
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 1,
+    'retry_delay': timedelta(minutes=5),
+}
+
+dag = DAG(
+    '{{ dag_id }}',
+    default_args=default_args,
+    description='A simple example DAG',
+    schedule_interval='{{ schedule_interval }}',
+    catchup={{ catchup | lower }},
+)
+
+hello_task = BashOperator(
+    task_id='hello_world',
+    bash_command='echo "Hello World from {{ dag_id }}!"',
+    dag=dag,
+)
+```
+
+## Outputs
+
+This example outputs:
+- `dag_checksum`: The CRC32C checksum of the generated file
+- `dag_generation`: The GCS generation number
+- `dag_path`: The full GCS path of the generated file 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_providers {
+    mirage = {
+      source  = "localhost/my-org/mirage"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "mirage" {
+  # No configuration required
+}
+
+# Example: Generate a simple DAG from a GCS template
+resource "mirage_dag_generator" "simple_dag" {
+  dag_generator_backend_url = "https://your-backend-service.com"
+  template_gcs_path        = "gs://your-bucket/templates/simple_dag.py.j2"
+  target_gcs_path          = "gs://your-bucket/dags/simple_dag.py"
+  
+  context_json = jsonencode({
+    dag_id            = "simple_example_dag"
+    schedule_interval = "@daily"
+    owner            = "data-team"
+    start_date       = "2024-01-01"
+    catchup          = false
+  })
+  
+  use_gcp_service_account_auth = true
+}
+
+# Output the generated file information
+output "dag_checksum" {
+  value = mirage_dag_generator.simple_dag.generated_file_checksum
+}
+
+output "dag_generation" {
+  value = mirage_dag_generator.simple_dag.gcs_generation_number
+}
+
+output "dag_path" {
+  value = mirage_dag_generator.simple_dag.id
+} 

--- a/examples/inline-template/main.tf
+++ b/examples/inline-template/main.tf
@@ -1,0 +1,76 @@
+terraform {
+  required_providers {
+    mirage = {
+      source  = "localhost/my-org/mirage"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "mirage" {
+  # No configuration required
+}
+
+# Example: Generate a DAG using inline template content
+resource "mirage_dag_generator" "inline_dag" {
+  dag_generator_backend_url = "https://your-backend-service.com"
+  
+  # Use inline template content instead of GCS path
+  template_content = file("${path.module}/templates/data_pipeline.py.j2")
+  
+  target_gcs_path = "gs://your-bucket/dags/data_pipeline.py"
+  
+  context_json = jsonencode({
+    dag_id            = "data_pipeline_dag"
+    schedule_interval = "0 2 * * *"  # Daily at 2 AM
+    owner            = "analytics-team"
+    start_date       = "2024-01-01"
+    catchup          = false
+    max_active_runs  = 1
+    
+    # Pipeline configuration
+    source_table     = "raw_data.events"
+    target_table     = "processed_data.daily_metrics"
+    notification_emails = ["team@company.com"]
+    
+    # Task configuration
+    tasks = [
+      {
+        task_id = "extract_data"
+        command = "python /scripts/extract.py"
+        pool    = "default_pool"
+        retries = 3
+      },
+      {
+        task_id = "validate_data"
+        command = "python /scripts/validate.py"
+        pool    = "default_pool"
+        retries = 2
+      },
+      {
+        task_id = "transform_data"
+        command = "python /scripts/transform.py"
+        pool    = "heavy_pool"
+        retries = 2
+      },
+      {
+        task_id = "load_data"
+        command = "python /scripts/load.py"
+        pool    = "default_pool"
+        retries = 3
+      }
+    ]
+  })
+  
+  # Use service account authentication
+  use_gcp_service_account_auth = true
+}
+
+# Output the generated DAG information
+output "inline_dag_info" {
+  value = {
+    id         = mirage_dag_generator.inline_dag.id
+    checksum   = mirage_dag_generator.inline_dag.generated_file_checksum
+    generation = mirage_dag_generator.inline_dag.gcs_generation_number
+  }
+} 

--- a/examples/inline-template/templates/data_pipeline.py.j2
+++ b/examples/inline-template/templates/data_pipeline.py.j2
@@ -1,0 +1,65 @@
+from datetime import datetime, timedelta
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from airflow.operators.email import EmailOperator
+
+# Default arguments for all tasks
+default_args = {
+    'owner': '{{ owner }}',
+    'depends_on_past': False,
+    'start_date': datetime.strptime('{{ start_date }}', '%Y-%m-%d'),
+    'email': {{ notification_emails | tojson }},
+    'email_on_failure': True,
+    'email_on_retry': False,
+    'retries': 1,
+    'retry_delay': timedelta(minutes=5),
+}
+
+# Create the DAG
+dag = DAG(
+    '{{ dag_id }}',
+    default_args=default_args,
+    description='Data pipeline DAG generated from template',
+    schedule_interval='{{ schedule_interval }}',
+    catchup={{ catchup | lower }},
+    max_active_runs={{ max_active_runs }},
+    tags=['data-pipeline', 'analytics', 'generated'],
+)
+
+# Create tasks dynamically from context
+{% for task in tasks %}
+{{ task.task_id }} = BashOperator(
+    task_id='{{ task.task_id }}',
+    bash_command='{{ task.command }}',
+    pool='{{ task.pool }}',
+    retries={{ task.retries }},
+    dag=dag,
+)
+{% endfor %}
+
+# Set up task dependencies
+{% if tasks|length > 1 %}
+{% for i in range(tasks|length - 1) %}
+{{ tasks[i].task_id }} >> {{ tasks[i + 1].task_id }}
+{% endfor %}
+{% endif %}
+
+# Add notification task on success
+success_notification = EmailOperator(
+    task_id='success_notification',
+    to={{ notification_emails | tojson }},
+    subject='✅ {{ dag_id }} completed successfully',
+    html_content='''
+    <h3>Pipeline Completed Successfully</h3>
+    <p><strong>DAG:</strong> {{ dag_id }}</p>
+    <p><strong>Source Table:</strong> {{ source_table }}</p>
+    <p><strong>Target Table:</strong> {{ target_table }}</p>
+    <p><strong>Execution Date:</strong> {{ '{{ ds }}' }}</p>
+    ''',
+    dag=dag,
+)
+
+# Set success notification to run after the last task
+{% if tasks %}
+{{ tasks[-1].task_id }} >> success_notification
+{% endif %} 


### PR DESCRIPTION
Initial commit with README, provider documentation, resource usage guides, and example Terraform configurations for basic and inline template DAG generation. Includes sample Jinja2 templates and output references for generated Airflow DAGs in Google Cloud Storage.